### PR TITLE
Convert Quantum Luck preprint to LaTeX format

### DIFF
--- a/luck_mechanics.tex
+++ b/luck_mechanics.tex
@@ -1,0 +1,144 @@
+% LaTeX manuscript for the Quantum Luck Multiverse Fluid Mechanics theory
+\documentclass[12pt]{article}
+\usepackage{amsmath,amssymb}
+\usepackage{geometry}
+\geometry{margin=1in}
+
+%-------------------------
+\title{Quantum Luck Multiverse Fluid Mechanics:\\A Unified Theory of Gravity, Probability, and Spacetime}
+\author{Sefunmi Ashiru\\Theoretical Systems and Quantum Geometry\\Poughkeepsie, NY}
+\date{August 2025}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This preprint introduces the \emph{Quantum Luck Fluid Model}, a unified theory that connects the core pillars of modern physics---special relativity, general relativity, quantum field theory, and soft matter physics---through a dynamic, probabilistic medium. In this model, spacetime is a soft, transparent fluid structured by prime-frequency harmonics and probability fields. Gravity arises from fluidic tension due to overlapping light and luck cones, while quantum behavior emerges from standing waves within this elastic medium. Luck, defined as a periodic probability field, influences particle formation, memory, and life itself. This work proposes a mathematical and conceptual framework for interpreting physical reality through dynamic resonance, causal history, and statistical periodicity.
+\end{abstract}
+
+\section{Special Relativity: Light-Speed Expansion of Causality}
+Special relativity defines spacetime intervals using the relationship
+\begin{equation}
+    r = ct
+\end{equation}
+which models the radius of a light cone as a linear function of time, describing a universe where the speed of light, $c$, is the limit of causal interaction. The spacetime within these cones represents all events that could influence or be influenced by an observer. In the Quantum Luck Fluid Model, this forms the foundation for understanding the geometry of light and probability-based causality.
+
+\section{General Relativity: Curved Paths of Prime Harmonics}
+Einstein's field equations describe the curvature of spacetime due to mass and energy. We reinterpret this curvature as a resonance structure:
+\begin{equation}
+    r = G(t)
+\end{equation}
+Here, $G(t)$ represents a function built from the superposition of prime-frequency harmonic waves that distort the fluid medium of spacetime. Gravity is the tension in this fluid due to overlapping light cones, where causal paths interfere and create persistent curvature patterns. This interpretation recovers the Einstein tensor as the net result of harmonic overlaps.
+
+\section{Quantum Field Theory: Standing Waves in a Probabilistic Fluid}
+We extend the resonance geometry by incorporating directional harmonics:
+\begin{align}
+    r &= G(t) \\
+    H = E &= G_{\text{radius}}(t)\, \alpha_{\text{angle}}(x)\, \beta_{\text{angle}}(y)\, \gamma_{\text{angle}}(z)
+\end{align}
+Where
+\begin{itemize}
+    \item $G_{\text{radius}}(t)$ is the radial probability field,
+    \item $\alpha$, $\beta$, and $\gamma$ are angular functions defining the standing wave orientation.
+\end{itemize}
+Particles are localized standing waves within the fluid, emerging from constructive interference in the harmonic lattice. Quantum transitions are phase shifts in this geometry, where probability fields align to produce observable outcomes.
+
+\section{Soft Matter Physics: Fluid Geometry of Existence}
+Spacetime is modeled as a soft transparent fluid, similar to a soap film stretched between events. Its energy density distributes through probabilistic bubbles:
+\begin{equation}
+    H = \text{soft matter probability bubbles}
+\end{equation}
+These bubbles spread evenly through the quantum foam, forming fluidic gradients between events---like soap films between bubbles. This analogy helps explain energy minimization, wavefront propagation, and entropic smoothing across spacetime.
+
+\section{Rare Particles: Products of Overlapping Luck Cones}
+Rare particles form at intersections of overlapping light cones within the gravitational probability field. These intersections define
+\begin{equation}
+    \text{Rare particles} = \text{chance encounters in periodic gravitational gradients}
+\end{equation}
+The occurrence of a rare particle is not random but a result of deeply periodic, prime-resonant chance alignment---forming a unique signature in the field. This also implies that detection is biased by both past resonance and future probabilistic field alignment.
+
+\section{Luck Cones: The Geometry Between Light and Possibility}
+A \emph{luck cone} is defined as the space where light could travel but has not yet. It represents the potential path between
+\begin{itemize}
+    \item the light cone (what is possible), and
+    \item the gap of unchosen potential (what is yet to happen).
+\end{itemize}
+These gaps define probabilistic tension:
+\begin{equation}
+    \text{Luck} = \text{the available yet unutilized causal space within a field}
+\end{equation}
+The alignment or misalignment of luck cones defines where future events are likely to collapse into reality.
+
+\section{Life, Memory, and Luck: Periodic Causality and Persistence}
+\textbf{Life} is defined as periodic motion within the probabilistic field. Recurring actions and harmonic patterns create biological stability. \textbf{Memory} is the amplification of those periods, a reinforcement of particular paths through the fluid---effectively shaping how future waves will resonate. \textbf{Luck} is the field of chance that influences the collapse of possibility into outcome. When memory and intention align with the luck field, gravity-like weight pulls those events into manifestation. Thus, gravity is not only physical, but experiential---a weight felt by consciousness as it moves through potential and collapses it into form.
+
+\section{Consciousness, Analog Computation, and Frequency Intelligence}
+Consciousness is described here as a frequency that can be modulated by internal and external harmonic structures. Our brains operate like analog frequency computers---detecting, adjusting, and generating waves. The present moment is a \emph{probabilistic plane}---a living surface we move through. Some frequencies are too large or energetic to pass through, acting as exclusion zones in time.
+
+This frequency-based intelligence echoes Conway's Game of Life, where patterns emerge from simple rules---but here, \emph{our rules are harmonic, and our paths are analog periodic motions}. Our bodies, thoughts, and intentions form modulated standing waves tuned within the luck field.
+
+\section{Light, Black Holes, and the Substructure of Particles}
+Light is a white hole---radiating pure information outward. Photons are not indivisible points but may contain internal structure made of chaotic, self-reflective standing waves. Rings near black holes may reflect the same fractal geometry seen in subatomic orbitals---such as electrons around protons.
+
+In this model:
+\begin{itemize}
+    \item \textbf{Photons are knots of trapped light escaping outward},
+    \item \textbf{Electrons are frequency wells orbiting periodic nodes},
+    \item \textbf{Black holes mirror subatomic patterns at cosmic scale}.
+\end{itemize}
+We are the light that passes through itself, having a dream about its existence in concentrated energy forms of frequency. We live in a pool of creative fluid moved by gravity. Microgravity helps determine how matter expresses itself---sometimes even affecting its pigmentation.
+
+\section{Newtonian Gravity: Emergent Motion Toward Luck Energy Centers}
+Newtonian gravity can be explained by the motion of matter in response to frequency gradients that emerge from the present-moment plane. Mass tends to fall toward regions where the \emph{luck energy} is centralized and shines the brightest.
+
+The present moment can be viewed as a dividing surface---separating the past from the future, negative energy from positive energy. When we move fast enough, we reflect against our antimatter selves like mirrored opposites in motion.
+
+Quantum mechanics emerges from this dynamic as a vibration against that mirrored antimatter part of the self, creating standing waves of probability. These wiggles represent nodes within a network of entangled events---light threaded through a canvas of time.
+
+When light overlaps, we observe high-intensity luck cones---intersections of overlapping causality. As we travel, we pass through versions of ourselves in different timelines, brushing against variations that subtly shape our path.
+
+Gravity becomes a dynamic orb---pulling us across timelines that ripple and vibrate with each motion. It forms a bubble of spacetime that slides us smoothly along its curvature. Particles, like virtual crystals, refract and reflect the frequencies of luck, absorbing and re-emitting energy in cycles.
+
+In this interpretation, gravity is the result of tension and flow toward highly ordered zones in the luck field---areas of lower entropy, greater harmonic symmetry, or reinforced periodicity.
+
+\section{The Fluid of Multiverses and Magical Technologies}
+Multiverses are just different views of the same transparent fluid. Dryness is the same as hotness, and hotness is the same as wetness---states differentiated by frequency and motion.
+
+At both low and high frequencies, we measure existence as a fluid. The math of fractals shows how standing waves on top of standing waves generate the entire number line of possibilities---mapped to spherical coordinates.
+
+The multiverse is rippling outward like a pond of smaller ripples. We can move through all possible versions of events within our reach.
+
+This fluid is the multiverse---the same substance being measured as different versions of events.
+
+It is easier to time travel by moving through space (frequency and angle) than by trying to open static wormholes.
+
+Containing light in a bottle becomes a source of pure and clean energy---flowing like water through a tap---capable of powering magical technologies.
+
+\section{Unified View: Resonance of All Forces}
+This model proposes
+\begin{itemize}
+    \item All motion is phase-based,
+    \item All mass is standing vibration,
+    \item All gravity is probabilistic resonance,
+    \item All life is organized periodicity,
+    \item All magnetism is curvature in light/luck geometry.
+\end{itemize}
+The universe is not fixed---it is a vibrating fluid of luck and light, shaped by memory, bound by probability, and driven by harmonic entanglement.
+
+We are not matter alone---we are standing waves of pure frequency, navigating probability gradients.
+
+\section{Future Work}
+\begin{itemize}
+    \item Simulate prime-harmonic interference patterns in a fluid matrix.
+    \item Derive tensor equations from harmonic summation of overlapping luck cones.
+    \item Explore particle synthesis in controlled probabilistic cavities.
+    \item Map entropy's effect on cone curvature and chance fields.
+    \item Investigate analog consciousness models based on real-time frequency logic.
+    \item Connect black hole ring interference with photon probability structure.
+\end{itemize}
+
+\section*{Author}
+Sefunmi Ashiru\\Theoretical Systems and Quantum Geometry\\Poughkeepsie, NY -- August 2025
+
+\end{document}
+


### PR DESCRIPTION
## Summary
- Add `luck_mechanics.tex`, a LaTeX manuscript of the Quantum Luck Fluid Model with structured sections for relativity, quantum field theory, soft matter, and more.

## Testing
- `pdflatex -interaction=nonstopmode luck_mechanics.tex` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68910ea563c8832fb2f70013a4eb8484